### PR TITLE
add support for rbac v1 API endpoint

### DIFF
--- a/charts/controller/templates/_helpers.tmpl
+++ b/charts/controller/templates/_helpers.tmpl
@@ -2,9 +2,11 @@
 Set apiVersion based on Kubernetes version
 */}}
 {{- define "rbacAPIVersion" -}}
-{{- if ge .Capabilities.KubeVersion.Minor "6" -}}
+{{- if lt .Capabilities.KubeVersion.Minor "6" -}}
+rbac.authorization.k8s.io/v1alpha1
+{{- else if (and (ge .Capabilities.KubeVersion.Minor "6") (le .Capabilities.KubeVersion.Minor "7")) -}}
 rbac.authorization.k8s.io/v1beta1
 {{- else -}}
-rbac.authorization.k8s.io/v1alpha1
+rbac.authorization.k8s.io/v1
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
As of kubernetes 1.8 RBAC is now stable and the endpoint has changed to rbac.authorization.k8s.io/v1 . I have kept compatibility for older k8s versions. 

This is my first PR, let me know if something is missing!

List of PRs related to this:

controller: teamhephy/controller#6
router: teamhephy/router#5
monitor: teamhephy/monitor#1
fluentd: teamhephy/fluentd#2
builder: teamhephy/builder#1
