### PR TITLE
fix(charts): int cast in version comparison

### DIFF
--- a/charts/controller/templates/_helpers.tmpl
+++ b/charts/controller/templates/_helpers.tmpl
@@ -2,9 +2,9 @@
 Set apiVersion based on Kubernetes version
 */}}
 {{- define "rbacAPIVersion" -}}
-{{- if lt .Capabilities.KubeVersion.Minor "6" -}}
+{{- if (lt (int (.Capabilities.KubeVersion.Minor)) 6) -}}
 rbac.authorization.k8s.io/v1alpha1
-{{- else if (and (ge .Capabilities.KubeVersion.Minor "6") (le .Capabilities.KubeVersion.Minor "7")) -}}
+{{- else if (and (ge (int (.Capabilities.KubeVersion.Minor)) 6) (le (int (.Capabilities.KubeVersion.Minor)) 7)) -}}
 rbac.authorization.k8s.io/v1beta1
 {{- else -}}
 rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This fixes an issue with the latest Kube version 1.10 where "9" is greater than "10" because of string comparison rules

The RBAC roles were failing to be created because KubeMinor was not compared as integer.  There's also semverCompare that we could have used, but behavior of the GitVersion proved to be less repeatable across versions than the KubeMinor int.

(In particular the latest version of minikube seems to be confused about Capabilities.KubeVersion.GitVersion, I got "v1.9.0" on the latest minikube with K8S v1.10.0 deployed.)