### PR TITLE
XXX feat(controller): permit setting GUNICORN_WORKERS

### DIFF
--- a/charts/controller/templates/controller-deployment.yaml
+++ b/charts/controller/templates/controller-deployment.yaml
@@ -73,6 +73,10 @@ spec:
               value: "{{ .Values.global.registry_location }}"
             - name: "DEIS_REGISTRY_SECRET_PREFIX"
               value: "{{ .Values.global.secret_prefix }}"
+            - name: "GUNICORN_WORKERS"
+              value: "{{ .Values.global.gunicorn_workers }}"
+            - name: "CONN_MAX_AGE"
+              value: "{{ .Values.global.conn_max_age }}"
             - name: "SLUGRUNNER_IMAGE_NAME"
               valueFrom:
                 configMapKeyRef:

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -49,6 +49,21 @@ global:
   host_port: 5555
   # Prefix for the imagepull secret created when using private registry
   secret_prefix: "private-registry"
+  # Clusters with large nodes (24 CPU+) may need to lower or tune the number of GUNICORN_WORKERS.
+  #
+  # Default value is based on your number of CPUs:
+  # - (os.cpu_count() or 4) * 4 + 1
+  # This setting probably should not be higher than max_connections which defaults to 100
+  # gunicorn_workers: 13
+  # If there are enough gunicorn workers to use up max_connections, you may also want to reduce CONN_MAX_AGE
+  # so health checks time out their connection faster and don't use all available connections
+  #
+  # Valid values are a number of seconds, or 0 to disable persistent connections.
+  # Setting the value to "None" will ensure that connections are never timed out.
+  # - 0
+  # - 600
+  # - "None"
+  # conn_max_age: 600
   # Experimental feature to toggle using kubernetes ingress instead of the Deis router.
   #
   # Valid values are:

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -60,7 +60,7 @@ global:
   #
   # Valid values are a number of seconds, or 0 to disable persistent connections.
   # Setting the value to "None" will ensure that connections are never timed out.
-  # - 0
+  # - 0 
   # - 600
   # - "None"
   # conn_max_age: 600

--- a/rootfs/api/settings/production.py
+++ b/rootfs/api/settings/production.py
@@ -27,8 +27,6 @@ SILENCED_SYSTEM_CHECKS = [
     'security.W008'
 ]
 
-CONN_MAX_AGE = 60 * 3
-
 # SECURITY: change this to allowed fqdn's to prevent host poisioning attacks
 # https://docs.djangoproject.com/en/1.11/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = ['*']
@@ -368,7 +366,7 @@ DATABASES = {
         'HOST': os.environ.get('DEIS_DATABASE_SERVICE_HOST', ''),
         'PORT': os.environ.get('DEIS_DATABASE_SERVICE_PORT', 5432),
         # https://docs.djangoproject.com/en/1.11/ref/databases/#persistent-connections
-        'CONN_MAX_AGE': 600,
+        'CONN_MAX_AGE': os.environ.get('CONN_MAX_AGE', 600),
     }
 }
 


### PR DESCRIPTION
permit setting GUNICORN_WORKERS and CONN_MAX_AGE from global values.yaml

(an additional pull request to the umbrella 'workflow' chart will follow)