### PR TITLE
fix(api/migrations): fix migrations conflict without merge

### DIFF
--- a/rootfs/api/migrations/0028_config_termination_grace_period.py
+++ b/rootfs/api/migrations/0028_config_termination_grace_period.py
@@ -9,7 +9,7 @@ import jsonfield.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('api', '0026_release_exception'),
+        ('api', '0027_auto_20180424_1742'),
     ]
 
     operations = [


### PR DESCRIPTION
Fixing the conflicting migrations without using django's `python3 manage.py makemigrations --merge` . Personal taste.