### PR TITLE
chore(requirements): updating django version and dependencies

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,6 +1,6 @@
 # Deis controller requirements
 backoff==1.4.3
-Django==1.11.4
+Django==1.11.16
 django-auth-ldap==1.2.15
 django-cors-middleware==1.3.1
 django-guardian==1.4.9
@@ -17,7 +17,7 @@ packaging==16.8
 pyasn1==0.3.2
 psycopg2==2.7.3
 pyldap==2.4.37
-pyOpenSSL==17.2.0
+pyOpenSSL==17.5.0
 pytz==2017.2
-requests==2.18.4
+requests==2.19.1
 requests-toolbelt==0.8.0


### PR DESCRIPTION
Updating `Django` to newer version and `pyOpenSSL` in order to address security vulnerabilities. Also we need to address some code in order to upgrade `djangorestframework` package: https://github.com/teamhephy/controller/issues/80