### PR TITLE
chore(requirements): updating requests package for vulnerability

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -19,5 +19,5 @@ psycopg2==2.7.3
 pyldap==2.4.37
 pyOpenSSL==17.5.0
 pytz==2017.2
-requests==2.19.1
+requests==2.20.0
 requests-toolbelt==0.8.0


### PR DESCRIPTION
Updating requests package to 2.20.0 because of discovered vulnerability [CVE-2018-18074](https://nvd.nist.gov/vuln/detail/CVE-2018-18074)
