### PR TITLE
feat(deployment.py): add support fo annotations to deployments and carry forward

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -15,7 +15,7 @@ morph==0.1.2
 ndg-httpsclient==0.4.2
 packaging==16.8
 pyasn1==0.3.2
-psycopg2==2.7.3
+psycopg2-binary==2.7.5
 pyldap==2.4.37
 pyOpenSSL==17.5.0
 pytz==2017.2

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -19,5 +19,5 @@ psycopg2==2.7.3
 pyldap==2.4.37
 pyOpenSSL==17.5.0
 pytz==2017.2
-requests==2.19.1
+requests==2.20.0
 requests-toolbelt==0.8.0

--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -30,7 +30,7 @@ class Deployment(Resource):
 
         return response
 
-    def manifest(self, namespace, name, image, entrypoint, command, **kwargs):
+    def manifest(self, namespace, name, image, entrypoint, command, spec_annotations, **kwargs):
         replicas = kwargs.get('replicas', 0)
         batches = kwargs.get('deploy_batches', None)
         tags = kwargs.get('tags', {})
@@ -104,11 +104,14 @@ class Deployment(Resource):
         # pod manifest spec
         manifest['spec']['template'] = self.pod.manifest(namespace, name, image, **kwargs)
 
+        # set the old deployment spec annotations on this deployment
+        manifest['spec']['template']['metadata']['annotations'] = spec_annotations
+
         return manifest
 
-    def create(self, namespace, name, image, entrypoint, command, **kwargs):
+    def create(self, namespace, name, image, entrypoint, command, spec_annotations, **kwargs):
         manifest = self.manifest(namespace, name, image,
-                                 entrypoint, command, **kwargs)
+                                 entrypoint, command, spec_annotations, **kwargs)
 
         url = self.api("/namespaces/{}/deployments", namespace)
         response = self.http_post(url, json=manifest)
@@ -124,9 +127,9 @@ class Deployment(Resource):
 
         return response
 
-    def update(self, namespace, name, image, entrypoint, command, **kwargs):
+    def update(self, namespace, name, image, entrypoint, command, spec_annotations, **kwargs):
         manifest = self.manifest(namespace, name, image,
-                                 entrypoint, command, **kwargs)
+                                 entrypoint, command, spec_annotations, **kwargs)
 
         url = self.api("/namespaces/{}/deployments/{}", namespace, name)
         response = self.http_put(url, json=manifest)

--- a/rootfs/scheduler/tests/test_deployments.py
+++ b/rootfs/scheduler/tests/test_deployments.py
@@ -243,6 +243,51 @@ class DeploymentsTest(TestCase):
             data
         )
 
+    def test_get_deployment_annotations(self):
+        """
+        Look at the annotations on the Deployment object
+        """
+        # test success
+        kwargs = {
+            'spec_annotations': {'iam.amazonaws.com/role': 'role-arn'},
+        }
+        deployment = self.create(**kwargs)
+        data = self.scheduler.deployment.get(self.namespace, deployment).json()
+
+        self.assertDictContainsSubset(
+            {
+                'iam.amazonaws.com/role': 'role-arn'
+            },
+            data['spec']['template']['metadata']['annotations']
+        )
+
+    def test_get_pod_annotations(self):
+        """
+        Look at the Pod annotations that the Deployment created
+        """
+        kwargs = {
+            'spec_annotations': {
+                'iam.amazonaws.com/role': 'role-arn-pods',
+                'nginx.ingress.kubernetes.io/app-root': '/rootfs',
+                'sidecar.istio.io/inject': 'true'
+            },
+        }
+        deployment = self.create(**kwargs)
+        data = self.scheduler.deployment.get(self.namespace, deployment).json()
+        self.assertEqual(data['kind'], 'Deployment')
+        self.assertEqual(data['metadata']['name'], deployment)
+
+        labels = {'app': self.namespace, 'version': 'v99', 'type': 'web'}
+        pods = self.scheduler.pod.get(self.namespace, labels=labels).json()
+        self.assertDictEqual(
+            {
+                'iam.amazonaws.com/role': 'role-arn-pods',
+                'nginx.ingress.kubernetes.io/app-root': '/rootfs',
+                'sidecar.istio.io/inject': 'true'
+            },
+            pods['items'][0]['metadata']['annotations']
+        )
+
     def test_check_for_failed_events(self):
         deploy_name = self.create(self.namespace)
         deployment = self.scheduler.deployment.get(self.namespace, deploy_name).json()

--- a/rootfs/scheduler/tests/test_deployments.py
+++ b/rootfs/scheduler/tests/test_deployments.py
@@ -25,6 +25,7 @@ class DeploymentsTest(TestCase):
             'image': 'quay.io/fake/image',
             'entrypoint': 'sh',
             'command': 'start',
+            'spec_annotations': kwargs.get('spec_annotations', {}),
         }
 
         deployment = self.scheduler.deployment.create(namespace, name, **kwargs)
@@ -45,6 +46,7 @@ class DeploymentsTest(TestCase):
             'image': 'quay.io/fake/image',
             'entrypoint': 'sh',
             'command': 'start',
+            'spec_annotations': kwargs.get('spec_annotations', {}),
         }
 
         deployment = self.scheduler.deployment.update(namespace, name, **kwargs)

--- a/rootfs/scheduler/tests/test_horizontalpodautoscaler.py
+++ b/rootfs/scheduler/tests/test_horizontalpodautoscaler.py
@@ -27,6 +27,7 @@ class HorizontalPodAutoscalersTest(TestCase):
             'image': 'quay.io/fake/image',
             'entrypoint': 'sh',
             'command': 'start',
+            'spec_annotations': kwargs.get('spec_annotations', {}),
         }
 
         # create a Deployment to test HPA with
@@ -75,6 +76,7 @@ class HorizontalPodAutoscalersTest(TestCase):
             'image': 'quay.io/fake/image',
             'entrypoint': 'sh',
             'command': 'start',
+            'spec_annotations': kwargs.get('spec_annotations', {}),
         }
 
         deployment = self.scheduler.deployment.update(namespace, name, **d_kwargs)

--- a/rootfs/scheduler/tests/test_horizontalpodautoscaler_12_lower.py
+++ b/rootfs/scheduler/tests/test_horizontalpodautoscaler_12_lower.py
@@ -31,6 +31,7 @@ class HorizontalPodAutoscalersTest(TestCase):
             'image': 'quay.io/fake/image',
             'entrypoint': 'sh',
             'command': 'start',
+            'spec_annotations': kwargs.get('spec_annotations', {}),
         }
 
         # create a Deployment to test HPA with
@@ -79,6 +80,7 @@ class HorizontalPodAutoscalersTest(TestCase):
             'image': 'quay.io/fake/image',
             'entrypoint': 'sh',
             'command': 'start',
+            'spec_annotations': kwargs.get('spec_annotations', {}),
         }
 
         deployment = self.scheduler.deployment.update(namespace, name, **kwargs)


### PR DESCRIPTION
closes https://github.com/teamhephy/workflow/issues/73

Requires manual edit on the deployment: 

```
kubectl edit deployment rocksolidapp-web -n rocksolidapp
```

Then edit the part:

```
...
spec:
  (...skipping top parts...)
  template:
    metadata:
      annotations:
        iam.amazonaws.com/role: role-arn-pods
        nginx.ingress.kubernetes.io/app-root: /rootfs
        sidecar.istio.io/inject: "true"
      creationTimestamp: null
      labels:
        app: rocksolidapp
        heritage: deis
        type: web
        version: v39
      name: rocksolidapp-web
      namespace: rocksolidapp
```

and add the annotations on the `deployment['spec']['template']['metadata']['annotations']` and the controller preserves these annotations for all releases after that. :anchor: 

After a new release or scale event the Pods of an app will have this yaml:

```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    iam.amazonaws.com/role: role-arn-pods
    nginx.ingress.kubernetes.io/app-root: /rootfs
    sidecar.istio.io/inject: "true"
  creationTimestamp: 2018-11-07T14:45:50Z
  generateName: rocksolidapp-web-5b68dc7d85-
  labels:
    app: rocksolidapp
    heritage: deis
(...skipping bottom parts...)
```

:+1:  :rocket: :shipit: 