### PR TITLE
check image access on `deis pull`

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -520,6 +520,9 @@ class App(UuidAuditedModel):
         image = settings.SLUGRUNNER_IMAGE if release.build.type == 'buildpack' else release.image
 
         try:
+            # check access to the image, so users can't exploit the k8s image cache
+            # to gain access to other users' images
+            release.check_image_access()
             # create the application config in k8s (secret in this case) for all deploy objects
             self.set_application_config(release)
             # only buildpack apps need access to object storage

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -35,6 +35,7 @@ def _mock_run(*args, **kwargs):
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
 @mock.patch('api.models.release.docker_get_port', mock_port)
+@mock.patch('api.models.release.docker_check_access', lambda *args: None)
 class AppTest(DeisTestCase):
     """Tests creation of applications"""
 

--- a/rootfs/api/tests/test_config.py
+++ b/rootfs/api/tests/test_config.py
@@ -21,6 +21,7 @@ import requests_mock
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
 @mock.patch('api.models.release.docker_get_port', mock_port)
+@mock.patch('api.models.release.docker_check_access', lambda *args: None)
 class ConfigTest(DeisTransactionTestCase):
     """Tests setting and updating config values"""
 

--- a/rootfs/api/tests/test_healthchecks.py
+++ b/rootfs/api/tests/test_healthchecks.py
@@ -13,6 +13,7 @@ from api.tests import adapter, mock_port, DeisTransactionTestCase
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
 @mock.patch('api.models.release.docker_get_port', mock_port)
+@mock.patch('api.models.release.docker_check_access', lambda *args: None)
 class TestHealthchecks(DeisTransactionTestCase):
     """Tests setting and updating config values"""
 

--- a/rootfs/api/tests/test_hooks.py
+++ b/rootfs/api/tests/test_hooks.py
@@ -50,6 +50,7 @@ BAD_KEY = (
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
 @mock.patch('api.models.release.docker_get_port', mock_port)
+@mock.patch('api.models.release.docker_check_access', lambda *args: None)
 class HookTest(DeisTransactionTestCase):
 
     """Tests API hooks used to trigger actions from external components"""

--- a/rootfs/api/tests/test_pods.py
+++ b/rootfs/api/tests/test_pods.py
@@ -21,6 +21,7 @@ import requests_mock
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
 @mock.patch('api.models.release.docker_get_port', mock_port)
+@mock.patch('api.models.release.docker_check_access', lambda *args: None)
 class PodTest(DeisTransactionTestCase):
     """Tests creation of pods on nodes"""
 

--- a/rootfs/api/tests/test_pods.py
+++ b/rootfs/api/tests/test_pods.py
@@ -322,7 +322,7 @@ class PodTest(DeisTransactionTestCase):
             self.assertIn(pod['type'], ['web', 'worker'])
             self.assertEqual(pod['release'], 'v2')
             # pod name is auto generated so use regex
-            self.assertRegex(pod['name'], app_id + '-(worker|web)-[0-9]{8,10}-[a-z0-9]{5}')
+            self.assertRegex(pod['name'], app_id + '-(worker|web)-[0-9]{7,10}-[a-z0-9]{5}')
 
     def test_pod_command_format(self, mock_requests):
         # regression test for https://github.com/deisthree/deis/pull/1285

--- a/rootfs/api/tests/test_release.py
+++ b/rootfs/api/tests/test_release.py
@@ -21,6 +21,7 @@ import requests_mock
 @requests_mock.Mocker(real_http=True, adapter=adapter)
 @mock.patch('api.models.release.publish_release', lambda *args: None)
 @mock.patch('api.models.release.docker_get_port', mock_port)
+@mock.patch('api.models.release.docker_check_access', lambda *args: None)
 class ReleaseTest(DeisTransactionTestCase):
 
     """Tests push notification from build system"""

--- a/rootfs/registry/__init__.py
+++ b/rootfs/registry/__init__.py
@@ -1,1 +1,1 @@
-from .dockerclient import publish_release, get_port, RegistryException  # noqa
+from .dockerclient import publish_release, get_port, check_access, RegistryException  # noqa

--- a/rootfs/registry/dockerclient.py
+++ b/rootfs/registry/dockerclient.py
@@ -154,6 +154,17 @@ class DockerClient(object):
         # inspect the image
         return self.client.inspect_image(target)
 
+    def check_access(self, target, creds=None):
+        """
+        Check access to the docker image, with the given creds (if any).
+        Due to the k8s docker image cache, we can't rely on k8s to do this
+        check - see https://github.com/teamhephy/workflow/issues/78
+        """
+        name, _ = docker.utils.parse_repository_tag(target)
+        self.login(name, creds)
+        self.inspect_image(target)
+        # no exception == success
+
 
 def check_blacklist(repo):
     """Check a Docker repository name for collision with deis/* components."""
@@ -197,3 +208,7 @@ def publish_release(source, target, deis_registry, creds=None):
 
 def get_port(target, deis_registry, creds=None):
     return DockerClient().get_port(target, deis_registry, creds)
+
+
+def check_access(target, creds=None):
+    return DockerClient().check_access(target, creds)


### PR DESCRIPTION
resolves https://github.com/teamhephy/workflow/issues/78

Essentially, this just attempts a `docker_client.inspect_image` (which downloads just the manifest, not the whole image) on `deis pull` and that raises an error if it's a private registry and the user didn't add the correct credentials to the app.

I think in the default hephy install, with the on-cluster `deis-registry`, you can still "steal" other users' source build images by doing `deis pull 127.0.0.1:5555/hephy/some-app:git-$githash`. But for that to work, you'd need to somehow guess the app name *and* the correct git hash - I don't think that's very likely. Plus, that stops working if you use a password-protected off-cluster registry for hephy.