### PR TITLE
(WIP) feat(controller): make K8S APIs capabilities data available at runtime

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -86,6 +86,12 @@ class KubeHTTPClient(object):
         data = response.json()
         return Version('{}.{}'.format(data['major'], data['minor']))
 
+    def apis(self):
+        """Get APIs: V1APIGroupList get_api_versions()"""
+        response = self.http_get('/apis')
+        data = response.json()
+        return data
+
     @staticmethod
     def parse_date(date):
         return datetime.strptime(date, KubeHTTPClient.DATETIME_FORMAT)


### PR DESCRIPTION
Ref #94

This is a start on runtime inspection of what APIs are provided by a cluster.  This is meant to replace the version number parsing that we use everywhere.