### PR TITLE
(WIP) Added support for AWS ECR

### DIFF
--- a/rootfs/api/models/release.py
+++ b/rootfs/api/models/release.py
@@ -209,7 +209,9 @@ class Release(UuidAuditedModel):
     def get_registry_ecr_auth(self):
         ecr_client = boto3.client('ecr', region_name='us-east-1')
         token = ecr_client.get_authorization_token()
-        username, password = base64.b64decode(token['authorizationData'][0]['authorizationToken']).decode().split(':')
+        auth_token = token['authorizationData'][0]['authorizationToken']
+        username, password = base64.b64decode(auth_token).decode().split(':')
+
         return {
             'username': username,
             'password': password,

--- a/rootfs/api/models/release.py
+++ b/rootfs/api/models/release.py
@@ -216,8 +216,6 @@ class Release(UuidAuditedModel):
             'email': self.owner.email
         }
 
-
-
     def previous(self):
         """
         Return the previous Release to this one.

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -21,3 +21,4 @@ pyOpenSSL==17.5.0
 pytz==2017.2
 requests==2.20.0
 requests-toolbelt==0.8.0
+boto3==1.9.120


### PR DESCRIPTION
Hi, wanted to get feedback on a more elegant way of integrating ECR, if that is something that would interest the Hephy team. 

So far as I'm aware the authorization token is not guaranteed to stay static so I decided to modify the controller to pull the auth details if the registry username is `aws-ecr`. 

Unsure of how up to date the contributing documentation is so please let me know if I've missed something glaring. 

## TODO 
- [ ] Make region configurable. 