### PR TITLE
(WIP) Temporary fix for autoscale on k8s-1.9+

### DIFF
--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -1,13 +1,22 @@
 from datetime import datetime, timedelta
 import json
 import time
+
+from packaging.version import parse
+
 from scheduler.resources import Resource
 from scheduler.exceptions import KubeException, KubeHTTPException
 
 
 class Deployment(Resource):
     api_prefix = 'apis'
-    api_version = 'extensions/v1beta1'
+
+    @property
+    def api_version(self):
+        if self.version() >= parse("1.9.0"):
+            return 'apps/v1'
+
+        return 'extensions/v1beta1'
 
     def get(self, namespace, name=None, **kwargs):
         """
@@ -43,7 +52,7 @@ class Deployment(Resource):
 
         manifest = {
             'kind': 'Deployment',
-            'apiVersion': 'extensions/v1beta1',
+            'apiVersion': self.api_version,
             'metadata': {
                 'name': name,
                 'labels': labels,

--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 import json
 import time
+import re
 
 from packaging.version import parse
 
@@ -11,9 +12,13 @@ from scheduler.exceptions import KubeException, KubeHTTPException
 class Deployment(Resource):
     api_prefix = 'apis'
 
+    def __sanitized_version(self):
+        """Remove non-numerics and non-decimal from our k8s API version"""
+        return parse(re.sub("[^0-9\.]", '', str(self.version())))
+
     @property
     def api_version(self):
-        if self.version() >= parse("1.9.0"):
+        if self.__sanitized_version() >= parse("1.9.0"):
             return 'apps/v1'
 
         return 'extensions/v1beta1'

--- a/rootfs/scheduler/tests/test_deployments.py
+++ b/rootfs/scheduler/tests/test_deployments.py
@@ -76,12 +76,6 @@ class DeploymentsTest(TestCase):
         self.scheduler.scale(namespace, name, **kwargs)
         return name
 
-    def unsanitized_version(self):
-        return parse("1.9+")
-
-    def sanitized_version(self):
-        return parse("1.9")
-
     def test_deployment_api_version_1_9_and_up(self):
         expected = 'apps/v1'
         deployment = copy.copy(self.scheduler.deployment)


### PR DESCRIPTION
This PR acts as a stopgap between the fix attempted in #86 and the whole-hog API capabilities work being done in #95 .

Effectively, this brings the changes from #86 back in, sanitizing the upstream API version number before the problematic comparison is done.

Just for an added bit of fun, I've included two related unit tests for `Deployment.api_version` to ensure proper behavior for cases that are already known.
