### PR TITLE
feat(controller): Add POD_IP environment variable with pod's IP address

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -1081,6 +1081,9 @@ class App(UuidAuditedModel):
         # set the image pull policy that is associated with the application container
         image_pull_policy = config.values.get('IMAGE_PULL_POLICY', settings.IMAGE_PULL_POLICY)
 
+        # set pod ip if this variable is set
+        set_pod_ip = config.values.get('DEIS_EXPOSE_POD_IP', settings.DEIS_EXPOSE_POD_IP)
+
         # create image pull secret if needed
         image_pull_secret_name = self.image_pull_secret(self.id, config.registry, release.image)
 
@@ -1113,7 +1116,8 @@ class App(UuidAuditedModel):
             'pod_termination_grace_period_seconds': pod_termination_grace_period_seconds,
             'pod_termination_grace_period_each': config.termination_grace_period,
             'image_pull_secret_name': image_pull_secret_name,
-            'image_pull_policy': image_pull_policy
+            'image_pull_policy': image_pull_policy,
+            'set_pod_ip': set_pod_ip
         }
 
     def set_application_config(self, release):

--- a/rootfs/api/settings/production.py
+++ b/rootfs/api/settings/production.py
@@ -269,6 +269,10 @@ EXPERIMENTAL_NATIVE_INGRESS_HOSTNAME = os.environ.get('EXPERIMENTAL_NATIVE_INGRE
 SLUGRUNNER_IMAGE = os.environ.get('SLUGRUNNER_IMAGE_NAME', 'quay.io/deisci/slugrunner:canary')  # noqa
 IMAGE_PULL_POLICY = os.environ.get('IMAGE_PULL_POLICY', "IfNotPresent")  # noqa
 
+# Pod IP Exposure
+DEIS_EXPOSE_POD_IP = bool(os.environ.get('DEIS_EXPOSE_POD_IP', False))
+
+
 # True, true, yes, y and more evaluate to True
 # False, false, no, n and more evaluate to False
 # https://docs.python.org/3/distutils/apiref.html?highlight=distutils.util#distutils.util.strtobool

--- a/rootfs/scheduler/resources/pod.py
+++ b/rootfs/scheduler/resources/pod.py
@@ -218,7 +218,7 @@ class Pod(Resource):
             })
 
         # Inject POD_IP variable with Pod's IP address
-        if os.environ.get("DEIS_EXPOSE_POD_IP", False):
+        if kwargs.get('set_pod_ip'):
             data["env"].append({
                 "name": "POD_IP",
                 "valueFrom": {

--- a/rootfs/scheduler/resources/pod.py
+++ b/rootfs/scheduler/resources/pod.py
@@ -217,6 +217,17 @@ class Pod(Resource):
                 "value": "1"
             })
 
+        # Inject POD_IP variable with Pod's IP address
+        if os.environ.get("DEIS_EXPOSE_POD_IP", False):
+            data["env"].append({
+                "name": "POD_IP",
+                "valueFrom": {
+                    "fieldRef": {
+                        "fieldPath": "status.podIP",
+                    }
+                }
+            })
+
         # list sorted by dict key name
         data['env'].sort(key=operator.itemgetter('name'))
 


### PR DESCRIPTION
Expose each pod's IP address as an environment variable `POD_IP`. This feature is really useful to us that we use python + django a lot. 

We are using prometheus-operator and we are adding business metrics to our applications and fetching them with prometheus. 

The main issue is that django requires you to set [`ALLOWED_HOSTS`](https://docs.djangoproject.com/en/2.2/ref/settings/#allowed-hosts) variable with a set of domains that Django can serve.

Prometheus uses the internal pod IP to fetch the metrics, and pod's IPs are dynamic. With this modification we can do something like this on python:

```python
ALLOWED_HOSTS = env.list('DJANGO_ALLOWED_HOSTS', default=['some-domain.com'])

if env('POD_IP'):
    ALLOWED_HOSTS.append('POD_IP')
```

this way prometheus would be able to fetch the metrics and not get a `400 BAD REQUEST` as a response.