### PR TITLE
Fix autoscale without breaking manual scaling

### DIFF
--- a/charts/controller/templates/controller-clusterrole.yaml
+++ b/charts/controller/templates/controller-clusterrole.yaml
@@ -44,7 +44,7 @@ rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["deployments"]
   verbs: ["get", "list", "create", "update", "delete"]
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions", "apps"]
   resources: ["deployments/scale", "replicasets/scale"]
   verbs: ["get", "update"]
 - apiGroups: ["extensions", "autoscaling"]

--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -520,6 +520,9 @@ class App(UuidAuditedModel):
         image = settings.SLUGRUNNER_IMAGE if release.build.type == 'buildpack' else release.image
 
         try:
+            # check access to the image, so users can't exploit the k8s image cache
+            # to gain access to other users' images
+            release.check_image_access()
             # create the application config in k8s (secret in this case) for all deploy objects
             self.set_application_config(release)
             # only buildpack apps need access to object storage

--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -520,9 +520,6 @@ class App(UuidAuditedModel):
         image = settings.SLUGRUNNER_IMAGE if release.build.type == 'buildpack' else release.image
 
         try:
-            # check access to the image, so users can't exploit the k8s image cache
-            # to gain access to other users' images
-            release.check_image_access()
             # create the application config in k8s (secret in this case) for all deploy objects
             self.set_application_config(release)
             # only buildpack apps need access to object storage

--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -968,7 +968,9 @@ class App(UuidAuditedModel):
         """
         name = '{}-{}'.format(self.id, proc_type)
         # basically fake out a Deployment object (only thing we use) to assign to the HPA
-        target = {'kind': 'Deployment', 'metadata': {'name': name}}
+        target = {'apiVersion': 'extensions/v1beta1',
+                  'kind': 'Deployment',
+                  'metadata': {'name': name}}
 
         try:
             # get the target for autoscaler, in this case Deployment

--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -1,11 +1,12 @@
 from collections import OrderedDict
 from datetime import datetime
 import logging
-from packaging.version import Version
+from packaging.version import Version, parse
 import requests
 import requests.exceptions
 from requests_toolbelt import user_agent
 import time
+import re
 from urllib.parse import urljoin
 
 from api import __version__ as deis_version
@@ -84,7 +85,9 @@ class KubeHTTPClient(object):
             raise KubeHTTPException(response, 'fetching Kubernetes version')
 
         data = response.json()
-        return Version('{}.{}'.format(data['major'], data['minor']))
+        parsed_version = parse(
+            re.sub("[^0-9\.]", '', str('{}.{}'.format(data['major'], data['minor']))))
+        return Version('{}'.format(parsed_version))
 
     @staticmethod
     def parse_date(date):

--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -14,7 +14,7 @@ class Deployment(Resource):
     @property
     def api_version(self):
         if self.version() >= parse("1.9.0"):
-            return 'apps/v1'
+            return 'extensions/v1beta1'
 
         return 'extensions/v1beta1'
 

--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -1,13 +1,22 @@
 from datetime import datetime, timedelta
 import json
 import time
+
+from packaging.version import parse
+
 from scheduler.resources import Resource
 from scheduler.exceptions import KubeException, KubeHTTPException
 
 
 class Deployment(Resource):
     api_prefix = 'apis'
-    api_version = 'extensions/v1beta1'
+
+    @property
+    def api_version(self):
+        if self.version() >= parse("1.9.0"):
+            return 'apps/v1'
+
+        return 'extensions/v1beta1'
 
     def get(self, namespace, name=None, **kwargs):
         """
@@ -43,7 +52,7 @@ class Deployment(Resource):
 
         manifest = {
             'kind': 'Deployment',
-            'apiVersion': 'extensions/v1beta1',
+            'apiVersion': self.api_version,
             'metadata': {
                 'name': name,
                 'labels': labels,

--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 import json
 import time
+import re
 
 from packaging.version import parse
 
@@ -11,9 +12,13 @@ from scheduler.exceptions import KubeException, KubeHTTPException
 class Deployment(Resource):
     api_prefix = 'apis'
 
+    def __sanitized_version(self):
+        """Remove non-numerics and non-decimal from our k8s API version"""
+        return parse(re.sub("[^0-9\.]", '', str(self.version())))
+
     @property
     def api_version(self):
-        if self.version() >= parse("1.9.0"):
+        if self.__sanitized_version() >= parse("1.9.0"):
             return 'apps/v1'
 
         return 'extensions/v1beta1'

--- a/rootfs/scheduler/resources/horizontalpodautoscaler.py
+++ b/rootfs/scheduler/resources/horizontalpodautoscaler.py
@@ -75,6 +75,7 @@ class HorizontalPodAutoscaler(Resource):
             manifest['spec']['targetCPUUtilizationPercentage'] = cpu_percent
 
             manifest['spec']['scaleTargetRef'] = {
+                'apiVersion': target['apiVersion'],
                 # only works with Deployments, RS and RC
                 'kind': target['kind'],
                 'name': target['metadata']['name'],

--- a/rootfs/scheduler/tests/test_deployments.py
+++ b/rootfs/scheduler/tests/test_deployments.py
@@ -96,7 +96,7 @@ class DeploymentsTest(TestCase):
 
         deployment = copy.copy(self.scheduler.deployment)
 
-        expected = 'apps/v1'
+        expected = 'extensions/v1beta1'
 
         for canonical in cases:
             deployment.version = mock.MagicMock(return_value=parse(canonical))

--- a/rootfs/scheduler/tests/test_deployments.py
+++ b/rootfs/scheduler/tests/test_deployments.py
@@ -76,12 +76,6 @@ class DeploymentsTest(TestCase):
         self.scheduler.scale(namespace, name, **kwargs)
         return name
 
-    def unsanitized_version(self):
-        return parse("1.9+")
-
-    def sanitized_version(self):
-        return parse("1.9")
-
     def test_deployment_api_version_1_9_and_up(self):
         expected = 'apps/v1'
         deployment = copy.copy(self.scheduler.deployment)


### PR DESCRIPTION
This PR is a WIP

We've been testing changes to make the Autoscale functionality via HPA work again.

Right now it looks like this image (`quay.io/kingdonb/controller:kb-fix-autoscale-take-5`) is successfully permitting a manual scale as well as an HPA to be created, like:

```
deis autoscale:set cmd -a testing-hephy --min=2 --max=5 --cpu-percent=10
```

The concession we had to make is that we don't know what has changed with manual scaling in `apps/v1` deployment, so we have left it at `extensions/v1beta1` API for deployments.

The `autoscaler/v1` HorizontalPodAutoscaler will only find the Deployment as a match if it is also provided with a `scaleTargetRef.apiVersion` selector that matches.  I added that here, and HPA now succeeds, assuming you have metrics-server properly configured so the HPA can get pod metrics to make scale decisions.

I also tested the manual `deis ps:scale -a testing-hephy cmd=1` behavior, which was broken by the last attempt we made to upgrade to `autoscaler/v1`.  We should make any reasonable efforts to upgrade the deployment to `apps/v1`, but that is not necessary in order to fix the autoscale feature (without unfortunately also breaking manual scaling.)  This PR seems to do both 👍!

The other frankly unacceptable concession I had to make was in `rootfs/api/models/app.py` where the HPA is created, I have hardcoded `'apiVersion': 'extensions/v1beta1'` as I'm not sure how the App resource is supposed to find out what the Deployment's api_version ought to be.

We discussed maybe adding an API version service that you can use from any module to determine what API versions are in use for what objects, but there is more discussion that needs to happen before it's clear what that piece ought to look like.

Also, since upgrading a resource's API version means necessarily destroying the old resource, we are going to need a bigger plan when it comes to upgrading deployments to `apps/v1`, since that step appears to be unavoidable, we might need to write code so that a cluster can recognize when these deployment upgrades are needed, and to handle them in a reasonable way.  I'm not sure how this can be done without potentially causing apps to have downtime.

(It should be perfectly safe to delete and recreate HPAs though, so for the upgrade guide, maybe we give that a little mention and this can go to press relatively as-is in the next release.)