### PR TITLE
chore(controller): permit umbrella override api group

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 # Deis Controller
 
+[![Build Status](https://travis-ci.org/teamhephy/controller.svg?branch=master)](https://travis-ci.org/teamhephy/controller)
 [![codecov.io](https://codecov.io/github/deis/controller/coverage.svg?branch=master)](https://codecov.io/github/deis/controller?branch=master)
 [![Docker Repository on Quay](https://quay.io/repository/deisci/controller/status "Docker Repository on Quay")](https://quay.io/repository/deisci/controller)
 

--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -1,7 +1,6 @@
 name: controller
-home: https://github.com/deisthree/controller
+home: https://github.com/teamhephy/controller
 version: <Will be populated by the ci before publishing the chart>
-description: Deis Workflow Controller (API).
+description: Hephy Workflow Controller (API).
 maintainers:
-  - name: Deis Team
-    email: engineering@deis.com
+- email: team@teamhephy.com

--- a/charts/controller/templates/_helpers.tmpl
+++ b/charts/controller/templates/_helpers.tmpl
@@ -10,3 +10,12 @@ rbac.authorization.k8s.io/v1alpha1
 rbac.authorization.k8s.io/v1
 {{- end -}}
 {{- end -}}
+{{- define "APIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
+extensions/v1beta1
+{{- else -}}
+apps/v1
+{{- end -}}
+{{- end -}}

--- a/charts/controller/templates/controller-clusterrole.yaml
+++ b/charts/controller/templates/controller-clusterrole.yaml
@@ -38,7 +38,7 @@ rules:
 - apiGroups: [""]
   resources: ["resourcequotas"]
   verbs: ["get", "create"]
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions", "apps"]
   resources: ["replicasets"]
   verbs: ["get", "list", "delete", "update"]
 - apiGroups: ["extensions", "apps"]

--- a/charts/controller/templates/controller-deployment.yaml
+++ b/charts/controller/templates/controller-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.global.api_group }}
 kind: Deployment
 metadata:
   name: deis-controller

--- a/charts/controller/templates/controller-deployment.yaml
+++ b/charts/controller/templates/controller-deployment.yaml
@@ -1,4 +1,10 @@
-apiVersion: {{ .Values.global.api_group }}
+{{- if .Capabilities.APIVersions.Has "apps/v1" }}
+apiVersion: apps/v1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" }}
+apiVersion: extensions/v1beta1
+{{- else }}
+apiVersion: apps/v1
+{{- end }}
 kind: Deployment
 metadata:
   name: deis-controller

--- a/charts/controller/templates/controller-deployment.yaml
+++ b/charts/controller/templates/controller-deployment.yaml
@@ -1,10 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "apps/v1" }}
-apiVersion: apps/v1
-{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" }}
-apiVersion: extensions/v1beta1
-{{- else }}
-apiVersion: apps/v1
-{{- end }}
+apiVersion: {{ template "APIVersion" . }}
 kind: Deployment
 metadata:
   name: deis-controller

--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -391,7 +391,7 @@ def upsert_pods(controller, url):
     # turn RC / RS (which a Deployment creates) url into pods one
     url = url.replace(cache_key(controller['metadata']['name']), '')
     if '_replicasets_' in url:
-        # We need to try to replace both just in case, one or the other exists (api backwards compatibility)
+        # Try replacing both just in case one or the other exists (api backwards compatibility)
         url = url.replace('_replicasets_', '_pods').replace('apis_apps_v1', 'api_v1')  # noqa
         url = url.replace('_replicasets_', '_pods').replace('apis_extensions_v1beta1', 'api_v1')  # noqa
     else:
@@ -515,7 +515,7 @@ def manage_replicasets(deployment, url):
 def update_deployment_status(namespaced_url, url, deployment, rs):
     # Fill out deployment.status for success as pods transition to running state
     pod_url = namespaced_url.replace('_replicasets', '_pods').replace('apis_apps_v1', 'api_v1')  # noqa
-    # We need to try to replace both just in case, one or the other exists (api backwards compatibility)
+    # Try replacing both just in case one or the other exists (api backwards compatibility)
     pod_url = pod_url.replace('_replicasets', '_pods').replace('apis_extensions_v1beta1', 'api_v1')  # noqa
     while True:
         # The below needs to be done to emulate Deployment handling things

--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -391,7 +391,9 @@ def upsert_pods(controller, url):
     # turn RC / RS (which a Deployment creates) url into pods one
     url = url.replace(cache_key(controller['metadata']['name']), '')
     if '_replicasets_' in url:
+        # We need to try to replace both just in case, one or the other exists (api backwards compatibility)
         url = url.replace('_replicasets_', '_pods').replace('apis_apps_v1', 'api_v1')  # noqa
+        url = url.replace('_replicasets_', '_pods').replace('apis_extensions_v1beta1', 'api_v1')  # noqa
     else:
         url = url.replace('_replicationcontrollers_', '_pods')
     # make sure url only has up to "_pods"
@@ -450,7 +452,6 @@ def manage_replicasets(deployment, url):
 
     # get RS url
     rs_url = url.replace('_deployments_', '_replicasets_')
-    rs_url = rs_url.replace('apis_extensions_v1beta1_', 'apis_apps_v1_')
     rs_url += '_' + pod_hash
     namespaced_url = rs_url[0:(rs_url.find("_replicasets") + 12)]
 
@@ -514,6 +515,8 @@ def manage_replicasets(deployment, url):
 def update_deployment_status(namespaced_url, url, deployment, rs):
     # Fill out deployment.status for success as pods transition to running state
     pod_url = namespaced_url.replace('_replicasets', '_pods').replace('apis_apps_v1', 'api_v1')  # noqa
+    # We need to try to replace both just in case, one or the other exists (api backwards compatibility)
+    pod_url = pod_url.replace('_replicasets', '_pods').replace('apis_extensions_v1beta1', 'api_v1')  # noqa
     while True:
         # The below needs to be done to emulate Deployment handling things
         # always cleanup pods

--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -450,6 +450,7 @@ def manage_replicasets(deployment, url):
 
     # get RS url
     rs_url = url.replace('_deployments_', '_replicasets_')
+    rs_url = rs_url.replace('apis_extensions_v1beta1_', 'apis_apps_v1_')
     rs_url += '_' + pod_hash
     namespaced_url = rs_url[0:(rs_url.find("_replicasets") + 12)]
 

--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -336,7 +336,7 @@ def delete_pods(pods, current, desired):
 
 
 def create_pods(url, labels, base, new_pods):
-    # Start by fetching available pods in the Namespace that fit the profile
+    # Start by fetching available pods in the Namespace that fit the procfile
     # and prune down if needed, Otherwise go into the addition logic here
     for _ in range(new_pods):
         data = base.copy()
@@ -391,7 +391,7 @@ def upsert_pods(controller, url):
     # turn RC / RS (which a Deployment creates) url into pods one
     url = url.replace(cache_key(controller['metadata']['name']), '')
     if '_replicasets_' in url:
-        url = url.replace('_replicasets_', '_pods').replace('apis_extensions_v1beta1', 'api_v1')  # noqa
+        url = url.replace('_replicasets_', '_pods').replace('apis_apps_v1', 'api_v1')  # noqa
     else:
         url = url.replace('_replicationcontrollers_', '_pods')
     # make sure url only has up to "_pods"
@@ -513,7 +513,7 @@ def manage_replicasets(deployment, url):
 
 def update_deployment_status(namespaced_url, url, deployment, rs):
     # Fill out deployment.status for success as pods transition to running state
-    pod_url = namespaced_url.replace('_replicasets', '_pods').replace('apis_extensions_v1beta1', 'api_v1')  # noqa
+    pod_url = namespaced_url.replace('_replicasets', '_pods').replace('apis_apps_v1', 'api_v1')  # noqa
     while True:
         # The below needs to be done to emulate Deployment handling things
         # always cleanup pods

--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -13,8 +13,10 @@ class Deployment(Resource):
 
     @property
     def api_version(self):
+        # API locations have changed since 1.9 and deprecated in 1.16
+        # https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
         if self.version() >= parse("1.9.0"):
-            return 'extensions/v1beta1'
+            return 'apps/v1'
 
         return 'extensions/v1beta1'
 

--- a/rootfs/scheduler/resources/ingress.py
+++ b/rootfs/scheduler/resources/ingress.py
@@ -23,6 +23,8 @@ class Ingress(Resource):
         return response
 
     def create(self, ingress, namespace, hostname):
+        # Ingress API will be deprecated in 1.20 to use networking.k8s.io/v1beta1
+        # https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
         url = "/apis/extensions/v1beta1/namespaces/%s/ingresses" % namespace
 
         data = {

--- a/rootfs/scheduler/resources/replicaset.py
+++ b/rootfs/scheduler/resources/replicaset.py
@@ -4,7 +4,7 @@ from scheduler.resources import Resource
 
 class ReplicaSet(Resource):
     api_prefix = 'apis'
-    api_version = 'extensions/v1beta1'
+    api_version = 'apps/v1'
     short_name = 'rs'
 
     def get(self, namespace, name=None, **kwargs):

--- a/rootfs/scheduler/resources/replicaset.py
+++ b/rootfs/scheduler/resources/replicaset.py
@@ -1,11 +1,21 @@
 from scheduler.exceptions import KubeHTTPException
 from scheduler.resources import Resource
 
+from packaging.version import parse
+
 
 class ReplicaSet(Resource):
     api_prefix = 'apis'
-    api_version = 'apps/v1'
     short_name = 'rs'
+
+    @property
+    def api_version(self):
+        # API locations have changed since 1.9 and deprecated in 1.16
+        # https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
+        if self.version() >= parse("1.9.0"):
+            return 'apps/v1'
+
+        return 'extensions/v1beta1'
 
     def get(self, namespace, name=None, **kwargs):
         """

--- a/rootfs/scheduler/tests/test_deployments.py
+++ b/rootfs/scheduler/tests/test_deployments.py
@@ -96,7 +96,7 @@ class DeploymentsTest(TestCase):
 
         deployment = copy.copy(self.scheduler.deployment)
 
-        expected = 'extensions/v1beta1'
+        expected = 'apps/v1'
 
         for canonical in cases:
             deployment.version = mock.MagicMock(return_value=parse(canonical))


### PR DESCRIPTION
This is the last PR to submit in the series upgrading the charts for K8s 1.16 in Hephy Workflow v2.23, unless I missed one.

This probably should not be merged without validating the e2e suite, I think that does not need any upgrade though because it does not deploy, only creates a Pod which was already at v1 quite some time ago.

I believe that this will not work without further RBAC changes that must be made in a later commit. I have not done enough research to say what must change exactly. There are also further changes needed in router based on my testing, but again I can't say exactly what is needed just yet.

See teamhephy/monitor#14 for more details about the change, which is the first PR opened in the series.  The full list of associated PRs is as follows:

requires teamhephy/monitor#14
requires teamhephy/minio#8
requires teamhephy/logger#8
requires teamhephy/fluentd#14
requires teamhephy/postgres#14
requires teamhephy/builder#52
requires teamhephy/nsq#9
requires teamhephy/redis#3
requires teamhephy/registry-proxy#2
requires teamhephy/registry-token-refresher#4
requires teamhephy/registry#5
requires teamhephy/router#44
requires teamhephy/workflow-manager#5
~requires teamhephy/workflow#105~