### PR TITLE
Ignore pod scheduling errors during deployments

### DIFF
--- a/rootfs/scheduler/resources/pod.py
+++ b/rootfs/scheduler/resources/pod.py
@@ -577,9 +577,11 @@ class Pod(Resource):
             "ErrImageNeverPull": "ErrImageNeverPullPolicy",
             # Not including this one for now as the message is not useful
             # "BackOff": "BackOffPullImage",
-            # FailedScheduling relates limits
-            "FailedScheduling": "FailedScheduling",
         }
+        # We want to be able to ignore pod scheduling errors as they might be temporary
+        if not os.environ.get("DEIS_IGNORE_SCHEDULING_FAILURE", False):
+            # FailedScheduling relates limits
+            event_errors["FailedScheduling"] = "FailedScheduling"
 
         # Nicer error than from the event
         # Often this gets to ImageBullBackOff before we can introspect tho


### PR DESCRIPTION
Ignore pod scheduling failures if the `DEIS_IGNORE_SCHEDULING_FAILURE` environment variable is set.

Pod scheduling errors during deployments, especially in autoscaled clusters, are often temporary. That's why we want to be able to ignore them.

Signed-off-by: Johann Fuechsl <johann@fuechsl.co>