### PR TITLE
Fix deployment status validation when number of pods more than 256

### DIFF
--- a/rootfs/scheduler/resources/deployment.py
+++ b/rootfs/scheduler/resources/deployment.py
@@ -275,9 +275,9 @@ class Deployment(Resource):
 
         if (
             'unavailableReplicas' in status or
-            ('replicas' not in status or status['replicas'] is not desired) or
-            ('updatedReplicas' not in status or status['updatedReplicas'] is not desired) or
-            ('availableReplicas' not in status or status['availableReplicas'] is not desired)
+            ('replicas' not in status or status['replicas'] != desired) or
+            ('updatedReplicas' not in status or status['updatedReplicas'] != desired) or
+            ('availableReplicas' not in status or status['availableReplicas'] != desired)
         ):
             return False, pods
 


### PR DESCRIPTION
`is not` is the way to compare objects but not numbers, now it works only because of this https://stackoverflow.com/questions/306313/is-operator-behaves-unexpectedly-with-integers. Once number of pods become more than 256 it stops working