### PR TITLE
chore(deps): bump django from 1.11.23 to 1.11.27 in /rootfs

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,6 +1,6 @@
 # Deis controller requirements
 backoff==1.4.3
-django==1.11.23
+django==1.11.27
 django-auth-ldap==1.2.15
 django-cors-middleware==1.3.1
 django-guardian==1.4.9


### PR DESCRIPTION
Signed-off-by: Cryptophobia <aouzounov@gmail.com>

Bumps django from 1.11.23 to 1.11.27.
