### PR TITLE
fix(Dockerfile): fix django python3-distutils on bionic 18.04

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -17,6 +17,7 @@ RUN buildDeps='gcc libffi-dev libpq-dev libldap2-dev libsasl2-dev python3-dev py
         libpq5 \
         libldap-2.4 \
         python3-minimal \
+        python3-distutils \
         # cryptography package needs pkg_resources
         python3-pkg-resources && \
     ln -s /usr/bin/python3 /usr/bin/python && \


### PR DESCRIPTION
Signed-off-by: Cryptophobia <aouzounov@gmail.com>

Ran into these errors during testing on controller startup:

```
ModuleNotFoundError: No module named 'distutils.util'
Django Version: 
Python 3.6.9

Django checks:
Traceback (most recent call last):
  File "/app/manage.py", line 12, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.6/dist-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.6/dist-packages/django/core/management/__init__.py", line 308, in execute
    settings.INSTALLED_APPS
  File "/usr/local/lib/python3.6/dist-packages/django/conf/__init__.py", line 56, in __getattr__
    self._setup(name)
  File "/usr/local/lib/python3.6/dist-packages/django/conf/__init__.py", line 41, in _setup
    self._wrapped = Settings(settings_module)
  File "/usr/local/lib/python3.6/dist-packages/django/conf/__init__.py", line 110, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/app/api/settings/production.py", line 4, in <module>
    from distutils.util import strtobool
ModuleNotFoundError: No module named 'distutils.util'

```