### PR TITLE
fix(scheduler): handle missing timestamps in pod events

### DIFF
--- a/rootfs/scheduler/resources/pod.py
+++ b/rootfs/scheduler/resources/pod.py
@@ -552,7 +552,7 @@ class Pod(Resource):
         if not events:
             events = []
         # make sure that events are sorted
-        events.sort(key=lambda x: x['lastTimestamp'])
+        events.sort(key=lambda x: x['lastTimestamp'] or '')
         return events
 
     def _handle_pod_errors(self, pod, reason, message):


### PR DESCRIPTION
Fix a crash during "deis run", when some pod events are missing a timestamp, see: https://github.com/kubernetes/kubernetes/issues/89689

Without this bugfix error like this can show up during deployments or deis run on Kubernetes 1.17.x:

Deployment:
> `Unknown Error (400): {"detail":"(app::deploy): unorderable types: str() < NoneType()"}`

Run:
> `Error: Unknown Error (503): {"detail":"my-app-run-x47pk (run): '<' not supported between instances of 'str' and 'NoneType'"}`

This bugfix has been verified to fix the "deis run" errors, but will likely fix the same error during deployment, since no other codepaths seem to sort event timestamps.

The deployment error doesn't happen every time, so some time is requried to see, if it is also fixed.