### PR TITLE
chore(rootfs): bump to hephy/base:v0.4.1 base image

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM hephy/base:v0.4.0
+FROM hephy/base:v0.4.1
 
 RUN adduser --system \
 	--shell /bin/bash \

--- a/rootfs/Dockerfile.test
+++ b/rootfs/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM hephy/base:v0.4.0
+FROM hephy/base:v0.4.1
 
 RUN adduser --system \
 	--shell /bin/bash \


### PR DESCRIPTION
Sync with the latest base image.