### PR TITLE
fix(charts): controller needs the "patch" perm

### DIFF
--- a/charts/controller/templates/controller-clusterrole.yaml
+++ b/charts/controller/templates/controller-clusterrole.yaml
@@ -46,7 +46,7 @@ rules:
   verbs: ["get", "list", "create", "update", "delete"]
 - apiGroups: ["extensions", "apps"]
   resources: ["deployments/scale", "replicasets/scale"]
-  verbs: ["get", "update"]
+  verbs: ["get", "update", "patch"]
 - apiGroups: ["extensions", "autoscaling"]
   resources: ["horizontalpodautoscalers"]
   verbs: ["get", "list", "create", "update", "delete"]

--- a/rootfs/scheduler/resources/scale.py
+++ b/rootfs/scheduler/resources/scale.py
@@ -1,12 +1,24 @@
 from scheduler.resources import Resource
 from scheduler.exceptions import KubeHTTPException
 
+from packaging.version import parse
+
 
 class Scale(Resource):
+
+    @property
+    def scale_api_version(self):
+        # API locations have changed since 1.9 and deprecated in 1.16
+        # https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
+        if self.version() >= parse("1.9.0"):
+            return 'autoscaling/v1'
+
+        return 'extensions/v1beta1'
+
     def manifest(self, namespace, name, replicas):
         manifest = {
             'kind': 'Scale',
-            'apiVersion': self.api_version,
+            'apiVersion': self.scale_api_version,
             'metadata': {
                 'namespace': namespace,
                 'name': name,


### PR DESCRIPTION
~Affects charts only~. Fixes this error:

```
User \"system:serviceaccount:deis:deis-controller\" cannot update resource \"deployments/scale\" in API group \"apps\"
```

Quite unhelpfully, the error messaging says "cannot update" here when it evidently means to warn you that it "cannot PATCH" in the HTTP verb parlance. I wonder if this "cannot update" language is our string, or if it came from upstream libraries?