### PR TITLE
fix(controller): apps/v1 in App model for hpa

### DIFF
--- a/rootfs/api/models/app.py
+++ b/rootfs/api/models/app.py
@@ -968,7 +968,7 @@ class App(UuidAuditedModel):
         """
         name = '{}-{}'.format(self.id, proc_type)
         # basically fake out a Deployment object (only thing we use) to assign to the HPA
-        target = {'apiVersion': 'extensions/v1beta1',
+        target = {'apiVersion': 'apps/v1',
                   'kind': 'Deployment',
                   'metadata': {'name': name}}
 


### PR DESCRIPTION
The old `extensions/v1beta1` string for Deployment API was hardcoded here. If you are using autoscale and haven't upgraded to a cluster version with apps/v1 yet, it's time. There is no permanent support for extensions/v1beta1 from here forward (and I believe this is actually the first patch that strictly breaks backwards compatibility.)