### PR TITLE
feat(HPAs): resolves #135 recreate HPAs from db on load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # If DEIS_REGISTRY is not set, try to populate it from legacy DEV_REGISTRY
 DEIS_REGISTRY ?= $(DEV_REGISTRY)
-IMAGE_PREFIX ?= deis
+IMAGE_PREFIX ?= hephy
 COMPONENT ?= controller
 SHORT_NAME ?= $(COMPONENT)
 

--- a/rootfs/api/management/commands/healthchecks.py
+++ b/rootfs/api/management/commands/healthchecks.py
@@ -5,6 +5,7 @@ import sys
 
 class Command(BaseCommand):
     """Management command for healthchecks"""
+
     def handle(self, *args, **options):
         """Ensure DB and other things are alive"""
         print("Checking if database is alive")

--- a/rootfs/api/management/commands/load_db_state_to_k8s.py
+++ b/rootfs/api/management/commands/load_db_state_to_k8s.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 from django.shortcuts import get_object_or_404
 
-from api.models import Key, App, Domain, Certificate, Service
+from api.models import Key, App, AppSettings, Domain, Certificate, Service
 from api.exceptions import DeisException, AlreadyExists
 
 
@@ -9,6 +9,7 @@ class Command(BaseCommand):
     """Management command for publishing Deis platform state from the database
     to k8s.
     """
+
     def handle(self, *args, **options):
         """Publishes Deis platform state from the database to kubernetes."""
         print("Publishing DB state to kubernetes...")
@@ -39,6 +40,16 @@ class Command(BaseCommand):
             except DeisException as error:
                 print('ERROR: There was a problem deploying {} '
                       'due to {}'.format(application, str(error)))
+
+            # deploy autoscaling HPAs for application
+            appsettings = AppSettings.objects.filter(app=application).order_by('-created')[0]
+            if appsettings.autoscale:
+                try:
+                    for proc_type in application.structure:
+                        application.autoscale(proc_type, appsettings.autoscale[proc_type])
+                except Exception as error:
+                    print('ERROR: There was a problem deploying HPAs for this {} proc_type '
+                          'of {} app due to error: {}'.format(proc_type, application, error))
 
         print("Done Publishing DB state to kubernetes.")
 


### PR DESCRIPTION
Signed-off-by: Cryptophobia <aouzounov@gmail.com>

resolves #135 

@dmcnaught @kingdonb 

Local unit test and local minikube testing passes for me. Had to modify the function.

There are multiple appsettings per app. We only care about the latest one. We use app.structure for the proc_types only if appsettings.autoscale is set. If autoscale is unset on deis, then the hpa should not be created and should return an error.

This is the intended behaviour as we assume deis/hephy controller is master of its own namespaces (apps).
