### PR TITLE
feat(controller): permit setting GUNICORN_WORKERS

### DIFF
--- a/charts/controller/templates/controller-deployment.yaml
+++ b/charts/controller/templates/controller-deployment.yaml
@@ -73,6 +73,10 @@ spec:
               value: "{{ .Values.global.registry_location }}"
             - name: "DEIS_REGISTRY_SECRET_PREFIX"
               value: "{{ .Values.global.secret_prefix }}"
+            - name: "GUNICORN_WORKERS"
+              value: "{{ .Values.global.gunicorn_workers }}"
+            - name: "CONN_MAX_AGE"
+              value: "{{ .Values.global.conn_max_age }}"
             - name: "SLUGRUNNER_IMAGE_NAME"
               valueFrom:
                 configMapKeyRef:

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -49,6 +49,21 @@ global:
   host_port: 5555
   # Prefix for the imagepull secret created when using private registry
   secret_prefix: "private-registry"
+  # Clusters with large nodes (24 CPU+) may need to lower or tune the number of GUNICORN_WORKERS.
+  #
+  # Default value is based on your number of CPUs:
+  # - (os.cpu_count() or 4) * 4 + 1
+  # This setting probably should not be higher than max_connections which defaults to 100
+  # gunicorn_workers: 13
+  # If there are enough gunicorn workers to use up max_connections, you may also want to reduce CONN_MAX_AGE
+  # so health checks time out their connection faster and don't use all available connections
+  #
+  # Valid values are a number of seconds, or 0 to disable persistent connections.
+  # Setting the value to "None" will ensure that connections are never timed out.
+  # - 0
+  # - 600
+  # - "None"
+  # conn_max_age: 600
   # Experimental feature to toggle using kubernetes ingress instead of the Deis router.
   #
   # Valid values are:


### PR DESCRIPTION
permit setting GUNICORN_WORKERS

This is the chart-only change. #75 had another separate change for CONN_MAX_AGE, but I could not get controller to build tonight... this variable is already mentioned in controller v2.21.2, though!

This chart-only change makes GUNICORN_WORKERS settable from in the controller chart.

#75 will close and we can reopen with whatever changes are needed for CONN_MAX_AGE, if that's still something we want to configure. (I think we weren't convinced this other setting is really needed, whenever that conversation last left off...)