### PR TITLE
chore(django): upgrade django to >= 2.2.20

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,6 +1,6 @@
 # Deis controller requirements
 backoff==1.8.0
-django==2.2.19,<3.0
+django>=2.2.20,<3.0
 django-auth-ldap==2.3.0,<3.0
 django-cors-middleware==1.5.0
 django-guardian==2.3.0


### PR DESCRIPTION
 - upgrading dango to 2.2.20

Signed-off-by: Cryptophobia <aouzounov@gmail.com>
