### PR TITLE
chore(ingress): update from extensions/v1beta1 to networking.k8s.io/v1

### DIFF
--- a/charts/controller/templates/controller-clusterrole.yaml
+++ b/charts/controller/templates/controller-clusterrole.yaml
@@ -51,7 +51,7 @@ rules:
   resources: ["horizontalpodautoscalers"]
   verbs: ["get", "list", "create", "update", "delete"]
 {{ if .Values.global.experimental_native_ingress }}
-- apiGroups: ["extensions"]
+- apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]
 {{- end -}}

--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -124,6 +124,7 @@ def get_namespace(url, resource_type):
     # correct back to proper namespace API
     url = url.replace('apis_autoscaling_v1', 'api_v1')
     url = url.replace('apis_extensions_v1beta1', 'api_v1')
+    url = url.replace('apis_networking.k8s.io_v1', 'api_v1')
     # check if this is a subresource
     subresource, resource_type, url = is_subresource(resource_type, url)
     # get namespace name
@@ -692,7 +693,7 @@ def post(request, context):
     # don't bother adding it to those two resources since they live outside namespace
     if resource_type not in ['nodes', 'namespaces']:
         namespace = request.url.replace(settings.SCHEDULER_URL + '/api/v1/namespaces/',  '')
-        namespace = namespace.replace(settings.SCHEDULER_URL + '/apis/extensions/v1beta1/namespaces/',  '')  # noqa
+        namespace = namespace.replace(settings.SCHEDULER_URL + '/apis/networking.k8s.io/v1/namespaces/',  '')  # noqa
         namespace = namespace.split('/')[0]
         data['metadata']['namespace'] = namespace
 

--- a/rootfs/scheduler/tests/test_ingress.py
+++ b/rootfs/scheduler/tests/test_ingress.py
@@ -35,7 +35,7 @@ class IngressTest(TestCase):
         data = response.json()
 
         self.assertEqual(response.status_code, 200, data)
-        self.assertEqual(data['apiVersion'], 'extensions/v1beta1')
+        self.assertEqual(data['apiVersion'], 'networking.k8s.io/v1')
         self.assertEqual(data['kind'], 'Ingress')
 
     def test_delete_failure(self):


### PR DESCRIPTION
Use networking.k8s.io/v1 ingress API

This is required for K8s v1.22.0, as extensions/v1beta1 ingress was deprecated and finally is removed.

I guess we can consider promoting the ingress feature out of "experimental" now that the underlying API is in GA,  🎉 !