### PR TITLE
chore(chart): update ingress-rule in chart

### DIFF
--- a/charts/controller/templates/controller-ingress-rule-http-80.yaml
+++ b/charts/controller/templates/controller-ingress-rule-http-80.yaml
@@ -2,7 +2,6 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  namespace: "{{ .Release.Namespace }}"
   name: "controller-api-server-ingress-http"
   labels:
     app: "controller"

--- a/charts/controller/templates/controller-ingress-rule-http-80.yaml
+++ b/charts/controller/templates/controller-ingress-rule-http-80.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.global.experimental_native_ingress }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: "{{ .Release.Namespace }}"
@@ -15,7 +15,10 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: deis-controller
-          servicePort: 80
+          service:
+            name: deis-controller
+            port:
+              number: 80
 {{- end }}

--- a/charts/controller/templates/controller-ingress-rule-http-80.yaml
+++ b/charts/controller/templates/controller-ingress-rule-http-80.yaml
@@ -9,6 +9,9 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+{{- if .Values.ingress_class }}
+  ingressClassName: {{ .Values.ingress_class }}
+{{- end }}
   rules:
   - host: deis.{{ .Values.platform_domain }}
     http:

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -18,6 +18,8 @@ k8s_api_verify_tls: "true"
 #
 # This will be the hostname that is used to build endpoints such as "deis.$HOSTNAME"
 platform_domain: ""
+# Set a value for ingressClassName, if IngressClass is needed.
+ingress_class: ""
 
 global:
   # Set the storage backend


### PR DESCRIPTION
The chart ingress rule needs to be updated to match the changes to controller, (in the next release we will support networking.k8s.io/v1 Ingress only, and the extensions/v1beta1 Ingress will be removed.)

The expectation is generally that people are upgrading their clusters and the older Ingress and other beta versions will be automatically upgraded, (but they must also be upgraded in the helm charts.)

Note: maybe we should add `ingressClassName` support before we release this change. It can be merged as-is, however I only stumbled upon this because I was trying to patch `ingressClassName` into the ingress rule, and I found the helm chart wasn't actually rendering the new version.

I will upgrade to K8s 1.22 again soon so we can flush out any more issues like this, (hopefully prior to making a next release!)
